### PR TITLE
I fix thee, Activitybot

### DIFF
--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -15,6 +15,9 @@ const THRESHOLD_SECONDS = _.parseInt(
 const COOLDOWN_SECONDS = _.parseInt(
 	config.get('activitybot.cooldown_seconds')
 );
+const RUN_INTERVAL_SECONDS = _.parseInt(
+	config.get('activitybot.run_interval_seconds')
+);
 
 const IGNORED_CHANNELS = config.get('activitybot.ignored_channels').split(',');
 
@@ -22,7 +25,8 @@ const coolingChannels = {};
 let messageTimestamps = {};
 
 
-const unixNow = ()=>Math.floor(Date.now() / 1000);
+const unixNow = () => Math.floor(Date.now() / 1000);
+
 
 /**
  * Add `msg`'s timestamp as UNIX epoch to the end of the array for
@@ -40,8 +44,11 @@ const tallyMessage = (msg)=>{
 	if(!_.has(messageTimestamps, channelKey)) {
 		messageTimestamps[channelKey] = [];
 	}
-	const unixTimestamp = Math.floor(msg.ts * 1000);
+	const unixTimestamp = Math.floor(msg.ts);
 	messageTimestamps[channelKey].push(unixTimestamp);
+	if(DEBUG) {
+		Slack.log(`[Activitybot]: <#${channelKey}>: ${unixTimestamp} ${JSON.stringify(msg)}`);
+	}
 };
 
 /**
@@ -97,7 +104,7 @@ const checkForActivityBursts = ()=>{
 				TARGET_CHANNEL,
 				`Something's going down in <#${channelKey}>!`
 			);
-			coolingChannels[channelKey] = unixNow();
+			coolingChannels[channelKey] = unixNow()
 		}
 		res[channelKey] = culled;
 		return res;
@@ -114,4 +121,4 @@ const checkForActivityBursts = ()=>{
 
 
 Slack.onMessage(tallyMessage);
-setInterval(checkForActivityBursts, 30*1000);
+setInterval(checkForActivityBursts, RUN_INTERVAL_SECONDS * 1000);

--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -89,10 +89,9 @@ const checkChannelCooldown = (channelKey)=>{
 const checkForActivityBursts = ()=>{
 	messageTimestamps = _.reduce(messageTimestamps, (res, timestamps, channelKey) => {
 		const channelIsOnCooldown = checkChannelCooldown(channelKey);
-		if(checkChannelCooldown(channelKey)) return res;
-
 		const culled = cullTimestamps(timestamps, THRESHOLD_SECONDS, channelKey);
-		if(culled.length >= MESSAGE_COUNT_THRESHOLD) {
+
+		if(culled.length >= MESSAGE_COUNT_THRESHOLD && !channelIsOnCooldown) {
 			// alert the troops
 			Slack.send(
 				TARGET_CHANNEL,

--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -25,7 +25,7 @@ const coolingChannels = {};
 let messageTimestamps = {};
 
 
-const unixNow = () => Math.floor(Date.now() / 1000);
+const unixNow = ()=>Math.floor(Date.now() / 1000);
 
 
 /**
@@ -62,7 +62,7 @@ const cullTimestamps = (timestamps, thresholdSeconds, channelKey)=>{
 			`[ActivityBot]: Culled <#${channelKey}> timestamps ${timestamps} -> ${culled}`
 		);
 	}
-	return culled
+	return culled;
 };
 
 /**
@@ -79,7 +79,7 @@ const checkChannelCooldown = (channelKey)=>{
 		// channel is now off cooldown
 		delete coolingChannels[channelKey];
 		if(DEBUG) {
-			Slack.log(`[Activitybot]: <#${channelKey}> is off cooldown`)
+			Slack.log(`[Activitybot]: <#${channelKey}> is off cooldown`);
 		}
 		return false;
 	}
@@ -91,7 +91,7 @@ const checkChannelCooldown = (channelKey)=>{
  * thresholds and notify #general about them.
  */
 const checkForActivityBursts = ()=>{
-	messageTimestamps = _.reduce(messageTimestamps, (res, timestamps, channelKey) => {
+	messageTimestamps = _.reduce(messageTimestamps, (res, timestamps, channelKey)=>{
 		const channelIsOnCooldown = checkChannelCooldown(channelKey);
 		const culled = cullTimestamps(timestamps, THRESHOLD_SECONDS, channelKey);
 
@@ -101,7 +101,7 @@ const checkForActivityBursts = ()=>{
 				TARGET_CHANNEL,
 				`Something's going down in <#${channelKey}>!`
 			);
-			coolingChannels[channelKey] = unixNow()
+			coolingChannels[channelKey] = unixNow();
 		}
 		res[channelKey] = culled;
 		return res;
@@ -112,7 +112,7 @@ const checkForActivityBursts = ()=>{
 			+ JSON.stringify(messageTimestamps)
 			+ ' '
 			+ JSON.stringify(coolingChannels, null, '  ')
-		)
+		);
 	}
 };
 

--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -36,8 +36,8 @@ const unixNow = ()=>Math.floor(Date.now() / 1000);
  */
 const tallyMessage = (msg)=>{
 	const channelIgnored = _.has(msg.channel, IGNORED_CHANNELS);
-	const messageIsThreadReply = msg.subtype == 'message_replied';
-	if(channelIgnored || messageIsThreadReply) {
+	const messageIsWeird = msg.subtype || msg.hidden;
+	if(channelIgnored || messageIsWeird) {
 		return;
 	}
 	const channelKey = `${msg.channel_id}|${msg.channel}`;

--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -26,6 +26,7 @@ let messageTimestamps = {};
 
 
 const unixNow = ()=>Math.floor(Date.now() / 1000);
+const debug(...args)=>DEBUG && Slack.log(args.join(' '))
 
 
 /**
@@ -57,10 +58,7 @@ const cullTimestamps = (timestamps, thresholdSeconds, channelKey)=>{
 	const minimumTimestamp = unixNow() - thresholdSeconds;
 	const cutoffIndex = _.sortedIndex(timestamps, minimumTimestamp);
 	const culled = _.slice(timestamps, cutoffIndex);
-	if(DEBUG) {
-		Slack.log(
-			`[ActivityBot]: Culled <#${channelKey}> timestamps ${timestamps} -> ${culled}`
-		);
+	debug(`[ActivityBot]: Culled <#${channelKey}> timestamps ${timestamps} -> ${culled}`);
 	}
 	return culled;
 };
@@ -78,9 +76,7 @@ const checkChannelCooldown = (channelKey)=>{
 	if(unixNow() - COOLDOWN_SECONDS > coolingChannels[channelKey]) {
 		// channel is now off cooldown
 		delete coolingChannels[channelKey];
-		if(DEBUG) {
-			Slack.log(`[Activitybot]: <#${channelKey}> is off cooldown`);
-		}
+		debug(`[Activitybot]: <#${channelKey}> is off cooldown`);
 		return false;
 	}
 	return true;
@@ -106,14 +102,11 @@ const checkForActivityBursts = ()=>{
 		res[channelKey] = culled;
 		return res;
 	}, {});
-	if(DEBUG) {
-		Slack.log(
-			'[Activitybot]: Finished checking activity. '
-			+ JSON.stringify(messageTimestamps)
-			+ ' '
-			+ JSON.stringify(coolingChannels, null, '  ')
-		);
-	}
+	debug(
+		'[Activitybot]: Finished checking activity',
+		JSON.stringify(messageTimestamps),
+		JSON.stringify(coolingChannels, null, '  ')
+	);
 };
 
 

--- a/bots/activity.bot.js
+++ b/bots/activity.bot.js
@@ -46,9 +46,6 @@ const tallyMessage = (msg)=>{
 	}
 	const unixTimestamp = Math.floor(msg.ts);
 	messageTimestamps[channelKey].push(unixTimestamp);
-	if(DEBUG) {
-		Slack.log(`[Activitybot]: <#${channelKey}>: ${unixTimestamp} ${JSON.stringify(msg)}`);
-	}
 };
 
 /**

--- a/config/default.js
+++ b/config/default.js
@@ -24,10 +24,10 @@ module.exports = {
 		run_interval_seconds: 30,
 		ignored_channels: 'general,feedback,events,diagnostics',
 		target_channel: 'general',
-		cooldown_seconds: 43200,
+		cooldown_seconds: 12 * 60 * 60,
 		threshold : {
 			message_count: 20,
-			seconds: 300
+			seconds: 5 * 60
 		}
 	}
 }

--- a/config/default.js
+++ b/config/default.js
@@ -21,6 +21,7 @@ module.exports = {
 	},
 	activitybot : {
 		debug : false,
+		run_interval_seconds: 30,
 		ignored_channels: 'general,feedback,events,diagnostics',
 		target_channel: 'general',
 		cooldown_seconds: 43200,

--- a/config/default.js
+++ b/config/default.js
@@ -23,7 +23,7 @@ module.exports = {
 		debug : false,
 		ignored_channels: 'general,feedback,events,diagnostics',
 		target_channel: 'general',
-		cooldown_seconds: 86400,
+		cooldown_seconds: 43200,
 		threshold : {
 			message_count: 20,
 			seconds: 300


### PR DESCRIPTION
Two major issues:

- As @JMTyler suspected, I was not modifying the timestamp arrays correctly; I thought that the arrays were being passed into the `_.forEach` iterator by reference, but a quick test showed they were not. In order to make modifying the `messageTimestamps` object cleaner, I swapped the `forEach` out for a `reduce`.
- Some timestamps were being stored in milliseconds and others in seconds. All timestamps are now seconds (standard Unix epoch).

Also simplified some of the logic by removing potential "optimizations" and added a few more debug messages.