### PR TITLE
Parse comic URLs from `mrkdwn` format

### DIFF
--- a/bots/webcomic.bot.js
+++ b/bots/webcomic.bot.js
@@ -35,22 +35,23 @@ const getComics = (arr, count=3)=>{
 Slack.onMessage(async (msg)=>{
 	try{
 		if(msg.text.startsWith('comic:')){
-			const link = msg.text.split('comic:')[1].trim().replace('<', '').replace('>', '');
-
-			await Gist.append(GistId, {
-				webcomics : [{
-					date: (new Date()).toISOString(),
-					link,
-					user : msg.user,
-					shared : false
-				}]
-			})
-			Slack.send(msg.channel, 'Webcomic saved!');
+			const match = msg.text.match(/<(.+)\|.*>/);
+			if(match){
+				const link = match[1];
+				await Gist.append(GistId, {
+					webcomics : [{
+						date: (new Date()).toISOString(),
+						link,
+						user : msg.user,
+						shared : false
+					}]
+				})
+				Slack.send(msg.channel, 'Webcomic saved!');
+			}
 		}
 
 		if(Slack.has(msg, 'test', 'comic')){
 			SendWebcomics();
-
 		}
 	}catch(err){
 		console.log(err)


### PR DESCRIPTION
URLs in messages coming from the Slack API are in [`mrkdwn` format](https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages). The current implementation pulls everything inside the brackets, resulting in the Sunday output looking like `https://i.redd.it/qtneahlg33u71.jpg%7Chttps://i.redd.it/qtneahlg33u71.jpg` (which URL-decodes to `https://i.redd.it/qtneahlg33u71.jpg|https://i.redd.it/qtneahlg33u71.jpg`) rather than just `https://i.redd.it/qtneahlg33u71.jpg`.